### PR TITLE
fix: exclude loopback from NFQUEUE interception on Linux

### DIFF
--- a/Linux/src/ProxyBridge.c
+++ b/Linux/src/ProxyBridge.c
@@ -2732,12 +2732,15 @@ bool ProxyBridge_Start(void)
 
     // setup iptables rules for packet interception - USE MANGLE table so it runs BEFORE nat
     log_message("setting up iptables rules");
-    // mangle table runs before nat, so we can mark packets there
+    // mangle table runs before nat, so we can mark packets there.
+    // Exclude loopback first: local (lo) traffic must never be queued and reinjected,
+    // otherwise non-trivial 127.0.0.0/8 responses stall. Loopback never needs proxying.
+    int ret0 = run_iptables_cmd("-t", "mangle", "-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT", NULL, NULL, NULL, NULL, NULL, NULL);
     int ret1 = run_iptables_cmd("-t", "mangle", "-A", "OUTPUT", "-p", "tcp", "-j", "NFQUEUE", "--queue-num", "0", NULL, NULL, NULL, NULL);
     int ret2 = run_iptables_cmd("-t", "mangle", "-A", "OUTPUT", "-p", "udp", "-j", "NFQUEUE", "--queue-num", "0", NULL, NULL, NULL, NULL);
 
-    if (ret1 != 0 || ret2 != 0) {
-        log_message("failed to add iptables rules ret1=%d ret2=%d", ret1, ret2);
+    if (ret0 != 0 || ret1 != 0 || ret2 != 0) {
+        log_message("failed to add iptables rules ret0=%d ret1=%d ret2=%d", ret0, ret1, ret2);
     } else {
         log_message("iptables nfqueue rules added successfully");
     }
@@ -2779,10 +2782,12 @@ bool ProxyBridge_Stop(void)
     running = false;
 
     // cleanup iptables
+    int ret0 = run_iptables_cmd("-t", "mangle", "-D", "OUTPUT", "-o", "lo", "-j", "ACCEPT", NULL, NULL, NULL, NULL, NULL, NULL);
     int ret1 = run_iptables_cmd("-t", "mangle", "-D", "OUTPUT", "-p", "tcp", "-j", "NFQUEUE", "--queue-num", "0", NULL, NULL, NULL, NULL);
     int ret2 = run_iptables_cmd("-t", "mangle", "-D", "OUTPUT", "-p", "udp", "-j", "NFQUEUE", "--queue-num", "0", NULL, NULL, NULL, NULL);
     int ret3 = run_iptables_cmd("-t", "nat", "-D", "OUTPUT", "-p", "tcp", "-m", "mark", "--mark", "1", "-j", "REDIRECT", "--to-port", "34010");
     int ret4 = run_iptables_cmd("-t", "nat", "-D", "OUTPUT", "-p", "udp", "-m", "mark", "--mark", "2", "-j", "REDIRECT", "--to-port", "34011");
+    (void)ret0;
     (void)ret1;
     (void)ret2;
     (void)ret3;
@@ -3041,6 +3046,7 @@ static void library_cleanup(void)
     {
         // Even if not running, ensure iptables rules are removed
         // This handles cases where the app crashed before calling Stop
+        run_iptables_cmd("-t", "mangle", "-D", "OUTPUT", "-o", "lo", "-j", "ACCEPT", NULL, NULL, NULL, NULL, NULL, NULL);
         run_iptables_cmd("-t", "mangle", "-D", "OUTPUT", "-p", "tcp", "-j", "NFQUEUE", "--queue-num", "0", NULL, NULL, NULL, NULL);
         run_iptables_cmd("-t", "mangle", "-D", "OUTPUT", "-p", "udp", "-j", "NFQUEUE", "--queue-num", "0", NULL, NULL, NULL, NULL);
         run_iptables_cmd("-t", "nat", "-D", "OUTPUT", "-p", "tcp", "-m", "mark", "--mark", "1", "-j", "REDIRECT", "--to-port", "34010");


### PR DESCRIPTION
<!-- Черновик описания Pull Request (по .github/PULL_REQUEST_TEMPLATE.md). Рабочий файл, не для коммита.
     Ссылку на Issue вставить после его создания. -->

## Pull Request Details

### Type of Change
- [x] Bug Fix

### Related GitHub Issue
**Issue Link:** https://github.com/InterceptSuite/ProxyBridge/issues/164

Closes #164

### Platform(s) Affected
- [x] Linux

---

## macOS Application Changes

### Does this pull request include changes to the macOS application?
- [x] No

---

## Description of Changes

### What does this pull request do?

Fixes heavy loopback (`127.0.0.0/8`) transfers stalling on Linux whenever ProxyBridge is
active. ProxyBridge sent every `OUTPUT` packet — including loopback — through NFQUEUE and
reinjected it; because `lo` has a 65536 MTU, loopback uses ~64 KB TCP segments that don't
survive the NFQUEUE -> userspace -> reinject path, so non-trivial local responses timed out
with 0 bytes (small responses and external traffic were unaffected). It reproduced even with
no rules and no proxy configured, i.e. it was the interception itself.

The fix inserts `-A OUTPUT -o lo -j ACCEPT` in `mangle/OUTPUT` before the NFQUEUE rules so
loopback bypasses the queue entirely, and removes it symmetrically in both cleanup paths
(`ProxyBridge_Stop` and the library destructor used by `--cleanup`). Loopback is never proxied
in the default configuration; this matches the Windows default (localhost is DIRECT unless
`LocalhostViaProxy` is enabled).

Scope is intentionally minimal: 3 insertions of the same idiom (setup + two cleanup paths),
IPv4 only (`-o lo` covers `127.0.0.0/8`; the project does not use ip6tables).

### How has this been tested?

- **Test environment:** Debian 13 (trixie), x86_64, built from this branch.
- **Test steps:** reproduce per the linked issue (16 MB file over `127.0.0.1:8080`), with
  interception active, before and after the fix; plus a proxy regression through a SOCKS5
  server.
- **Test results:**

  | Scenario (interception active) | Before | After |
  |---|---|---|
  | loopback `big.bin` (16 MB) | timeout, 0 bytes | 200, 0.014 s |
  | loopback small request | 200 | 200 |
  | external `ifconfig.me` | 200 | 200 |
  | `*:*:*:TCP:PROXY` via SOCKS5 (exit IP) | n/a | routed through proxy, loopback still 200 |
  | `--cleanup` | removes NFQUEUE rules | also removes the `-o lo` rule (no leftovers) |

### Compilation & Dependencies
- [x] My changes compile without errors
- [x] My changes do not introduce new dependencies

---

## Additional Context

**Authorship disclosure.** I want to be fully transparent: I am not a C developer and could
not have investigated or fixed this issue on my own. The root-cause analysis and the fix were
done entirely by Claude Code (Opus 4.8). I made a genuine effort to understand the change and
to verify that it is correct — see the reproduction and the before/after testing above,
including a SOCKS5 proxy regression — but the decision is entirely yours: accept this PR as-is,
request changes, or implement the fix yourselves. I am completely fine with any outcome; I would
simply rather be upfront than present this as my own work.

---

## Final Checklist
- [x] My code follows the project's coding style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes do not generate new warnings or errors
- [x] I have tested my changes on the target platform(s)
- [x] I have verified this change is based on the latest `dev` branch
- [x] I understand that pull requests without an associated GitHub issue will be rejected
