### PR TITLE
fix: enlarge buf in socks5_udp_associate to avoid 1-byte write past stack array

### DIFF
--- a/Linux/src/ProxyBridge.c
+++ b/Linux/src/ProxyBridge.c
@@ -1418,7 +1418,7 @@ static void* local_proxy_server(void *arg)
 // socks5 udp associate
 static int socks5_udp_associate(int s, struct sockaddr_in *relay_addr)
 {
-    unsigned char buf[512];
+    unsigned char buf[SOCKS5_BUFFER_SIZE];
     ssize_t len;
 
     // auth handshake


### PR DESCRIPTION
`socks5_udp_associate` declares a 512-byte stack buffer for the
RFC 1929 username/password sub-negotiation packet:

```c
unsigned char buf[512];
...
memcpy(buf + 2,          g_proxy_username, ulen);   // ulen ≤ 255
buf[2 + ulen] =          (unsigned char)plen;
memcpy(buf + 3 + ulen,   g_proxy_password, plen);   // plen ≤ 255
```

The packed frame is `1 + 1 + ulen + 1 + plen` bytes.
With both credentials at their maximum length (255 chars each,
enforced by `strncpy` in `ProxyBridge_SetProxyConfig`), the frame
is `3 + 255 + 255 = 513` bytes — one byte past the end of `buf[512]`.

The sibling function `socks5_connect()` performs the identical
credential packing but correctly uses `buf[SOCKS5_BUFFER_SIZE]`
(1024 bytes).  Align `socks5_udp_associate()` to use the same constant.