### PR TITLE
fix(linux): relay bind, config perms, GUI update security

### DIFF
--- a/Linux/gui/gui_config.c
+++ b/Linux/gui/gui_config.c
@@ -13,7 +13,7 @@ void save_config() {
             return;
         }
     } else if (chmod(CONFIG_DIR, 0700) != 0) {
-        perror("failed to tighten config dir permissions");
+        perror("chmod config dir failed");
     }
 
     int cfg_fd = open(CONFIG_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0600);
@@ -59,7 +59,7 @@ void save_config() {
 
 // load settings from file
 void load_config() {
-    chmod(CONFIG_PATH, 0600); // tighten legacy world-readable installs
+    chmod(CONFIG_PATH, 0600); // old installs might still be world readable
     FILE *f = fopen(CONFIG_PATH, "r");
     if (!f) return;
 

--- a/Linux/gui/gui_config.c
+++ b/Linux/gui/gui_config.c
@@ -21,6 +21,10 @@ void save_config() {
         printf("failed to save config to %s\n", CONFIG_PATH);
         return;
     }
+    // mode on open only hits create; tighten existing 0644 installs too
+    if (fchmod(cfg_fd, 0600) != 0) {
+        perror("chmod config file failed");
+    }
     FILE *f = fdopen(cfg_fd, "w");
     if (!f) {
         close(cfg_fd);

--- a/Linux/gui/gui_config.c
+++ b/Linux/gui/gui_config.c
@@ -1,4 +1,5 @@
 #include "gui.h"
+#include <fcntl.h>
 
 #define CONFIG_DIR "/etc/proxybridge"
 #define CONFIG_PATH "/etc/proxybridge/config.ini"
@@ -7,14 +8,22 @@
 void save_config() {
     struct stat st = {0};
     if (stat(CONFIG_DIR, &st) == -1) {
-        if (mkdir(CONFIG_DIR, 0755) != 0) {
+        if (mkdir(CONFIG_DIR, 0700) != 0) {
             perror("failed to create config dir");
             return;
         }
+    } else if (chmod(CONFIG_DIR, 0700) != 0) {
+        perror("failed to tighten config dir permissions");
     }
 
-    FILE *f = fopen(CONFIG_PATH, "w");
+    int cfg_fd = open(CONFIG_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (cfg_fd < 0) {
+        printf("failed to save config to %s\n", CONFIG_PATH);
+        return;
+    }
+    FILE *f = fdopen(cfg_fd, "w");
     if (!f) {
+        close(cfg_fd);
         printf("failed to save config to %s\n", CONFIG_PATH);
         return;
     }
@@ -50,6 +59,7 @@ void save_config() {
 
 // load settings from file
 void load_config() {
+    chmod(CONFIG_PATH, 0600); // tighten legacy world-readable installs
     FILE *f = fopen(CONFIG_PATH, "r");
     if (!f) return;
 

--- a/Linux/gui/main.c
+++ b/Linux/gui/main.c
@@ -1,4 +1,5 @@
 #include "gui.h"
+#include <ctype.h>
 
 // widgets
 GtkWidget *window;
@@ -34,54 +35,100 @@ static void on_dns_proxy_toggled(GtkCheckMenuItem *item, gpointer data) {
     save_config();
 }
 
-static void on_create_update_script_and_run() {
-    ProxyBridge_Stop();
-    const char *script_url = "https://raw.githubusercontent.com/InterceptSuite/ProxyBridge/refs/heads/master/Linux/deploy.sh";
-    char tmp_dir_tpl[] = "/tmp/pb_update_XXXXXX";
-    char *tmp_dir = mkdtemp(tmp_dir_tpl);
-    if (!tmp_dir) { fprintf(stderr, "Failed to create temp directory for update.\n"); exit(1); }
-    char script_path[512];
-    snprintf(script_path, sizeof(script_path), "%s/deploy.sh", tmp_dir);
+static bool tag_name_is_safe(const char *tag) {
+    if (!tag || !tag[0]) return false;
+    for (const char *p = tag; *p; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (!(isalnum(c) || c == '.' || c == '-' || c == '_'))
+            return false;
+    }
+    return true;
+}
 
-    pid_t pid = fork();
-    if (pid == -1) { fprintf(stderr, "Fork failed.\n"); exit(1); }
-    else if (pid == 0) { execlp("curl", "curl", "-s", "-o", script_path, script_url, NULL); _exit(127); }
-    else { int status; waitpid(pid, &status, 0); if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) { fprintf(stderr, "Failed to download update script.\n"); exit(1); } }
+static gboolean fetch_latest_release_json(char **out_body) {
+    char *argv[] = {
+        (char *)"curl",
+        (char *)"-sS",
+        (char *)"-H", (char *)"User-Agent: ProxyBridge-Linux",
+        (char *)"-H", (char *)"Accept: application/vnd.github+json",
+        (char *)"https://api.github.com/repos/InterceptSuite/ProxyBridge/releases/latest",
+        NULL
+    };
+    char *stdout_buf = NULL;
+    char *stderr_buf = NULL;
+    GError *error = NULL;
+    int exit_status = 0;
+    gboolean ok = g_spawn_sync(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL,
+                               &stdout_buf, &stderr_buf, &exit_status, &error);
+    if (!ok || exit_status != 0 || !stdout_buf || stdout_buf[0] == '\0') {
+        if (error) g_error_free(error);
+        g_free(stdout_buf);
+        g_free(stderr_buf);
+        return FALSE;
+    }
+    *out_body = stdout_buf;
+    g_free(stderr_buf);
+    return TRUE;
+}
 
-    if (chmod(script_path, S_IRWXU) != 0) { perror("chmod failed"); exit(1); }
-    execl("/bin/bash", "bash", script_path, NULL);
-    exit(0);
+static void open_release_page(const char *html_url) {
+    if (!html_url || !html_url[0]) return;
+    GError *error = NULL;
+    if (!gtk_show_uri_on_window(GTK_WINDOW(window), html_url, GDK_CURRENT_TIME, &error)) {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR,
+                     "Could not open release page: %s", error ? error->message : "unknown error");
+        if (error) g_error_free(error);
+    }
 }
 
 static void on_check_update(GtkWidget *widget, gpointer data) {
-    const char *url = "https://api.github.com/repos/InterceptSuite/ProxyBridge/releases/latest";
-    char *cmd = g_strdup_printf("curl -s -H \"User-Agent: ProxyBridge-Linux\" %s", url);
-    char *standard_output = NULL;
-    char *standard_error = NULL;
-    GError *error = NULL;
-    int exit_status = 0;
+    (void)widget;
+    (void)data;
 
-    gboolean result = g_spawn_command_line_sync(cmd, &standard_output, &standard_error, &exit_status, &error);
-    g_free(cmd);
-    if (!result) { show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Failed to launch release check: %s", error ? error->message : "Unknown"); if (error) g_error_free(error); return; }
-    if (exit_status != 0 || !standard_output || strlen(standard_output) == 0) { show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Update check failed (Exit: %d).", exit_status); g_free(standard_output); g_free(standard_error); return; }
+    char *release_json = NULL;
+    if (!fetch_latest_release_json(&release_json)) {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Update check failed (could not reach GitHub).");
+        return;
+    }
 
-    char *tag_name = extract_sub_json_str(standard_output, "tag_name");
-    g_free(standard_output); g_free(standard_error);
+    char *tag_name = extract_sub_json_str(release_json, "tag_name");
+    char *html_url = extract_sub_json_str(release_json, "html_url");
+    g_free(release_json);
 
-    if (!tag_name) { show_message(GTK_WINDOW(window), GTK_MESSAGE_WARNING, "Could not parse version info."); return; }
+    if (!tag_name || !tag_name_is_safe(tag_name)) {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_WARNING, "Could not parse version info.");
+        g_free(tag_name);
+        g_free(html_url);
+        return;
+    }
+
     char *current_tag = g_strdup_printf("v%s", PROXYBRIDGE_VERSION);
-
-    if (strcmp(tag_name, current_tag) == 0) { show_message(GTK_WINDOW(window), GTK_MESSAGE_INFO, "You are using the latest version (%s).", PROXYBRIDGE_VERSION); }
-    else {
-        GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "New version %s is available!\nCurrent: %s\n\nUpdate now?", tag_name, PROXYBRIDGE_VERSION);
-        gtk_dialog_add_button(GTK_DIALOG(dialog), "Download Now", GTK_RESPONSE_ACCEPT);
+    if (strcmp(tag_name, current_tag) == 0) {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_INFO,
+                     "You are using the latest version (%s).", PROXYBRIDGE_VERSION);
+    } else {
+        GtkWidget *dialog = gtk_message_dialog_new(
+            GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
+            "New version %s is available.\nCurrent: %s\n\nOpen the official GitHub release page to download?", tag_name, PROXYBRIDGE_VERSION);
+        gtk_dialog_add_button(GTK_DIALOG(dialog), "Open Release Page", GTK_RESPONSE_ACCEPT);
         gtk_dialog_add_button(GTK_DIALOG(dialog), "Close", GTK_RESPONSE_CANCEL);
         int resp = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_destroy(dialog);
-        if (resp == GTK_RESPONSE_ACCEPT) on_create_update_script_and_run();
+        if (resp == GTK_RESPONSE_ACCEPT) {
+            if (html_url && html_url[0])
+                open_release_page(html_url);
+            else {
+                char fallback[256];
+                snprintf(fallback, sizeof(fallback),
+                         "https://github.com/InterceptSuite/ProxyBridge/releases/tag/%s", tag_name);
+                open_release_page(fallback);
+            }
+        }
     }
-    g_free(current_tag); g_free(tag_name);
+
+    g_free(current_tag);
+    g_free(tag_name);
+    g_free(html_url);
 }
 
 static void on_about(GtkWidget *widget, gpointer data) {

--- a/Linux/gui/main.c
+++ b/Linux/gui/main.c
@@ -34,14 +34,62 @@ static void on_dns_proxy_toggled(GtkCheckMenuItem *item, gpointer data) {
     save_config();
 }
 
-static int tag_ok(const char *tag) {
-    if (!tag || !tag[0]) return 0;
-    for (const char *p = tag; *p; p++) {
-        char c = *p;
-        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-            (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_')
-            continue;
-        return 0;
+// same feed as windows/mac: https://download.interceptsuite.com/proxybridge.json
+#define UPD_FEED_URL "https://download.interceptsuite.com/proxybridge.json"
+
+static char *extract_platform_block(const char *json, const char *platform) {
+    char needle[64];
+    snprintf(needle, sizeof(needle), "\"%s\"", platform);
+    char *p = strstr(json, needle);
+    if (!p) return NULL;
+    char *brace = strchr(p, '{');
+    if (!brace) return NULL;
+    int depth = 0;
+    for (char *q = brace; *q; q++) {
+        if (*q == '{') depth++;
+        else if (*q == '}') {
+            depth--;
+            if (depth == 0)
+                return g_strndup(brace, (gsize)(q - brace + 1));
+        }
+    }
+    return NULL;
+}
+
+static void parse_ver(const char *s, int out[3]) {
+    out[0] = out[1] = out[2] = 0;
+    if (!s) return;
+    while (*s && (*s < '0' || *s > '9')) s++;
+    int i = 0;
+    while (*s && i < 3) {
+        if (*s >= '0' && *s <= '9') {
+            int n = 0;
+            while (*s >= '0' && *s <= '9') {
+                n = n * 10 + (*s - '0');
+                s++;
+            }
+            out[i++] = n;
+        } else if (*s == '.') {
+            s++;
+        } else {
+            break;
+        }
+    }
+}
+
+static int ver_cmp(const int a[3], const int b[3]) {
+    for (int i = 0; i < 3; i++) {
+        if (a[i] != b[i]) return a[i] < b[i] ? -1 : 1;
+    }
+    return 0;
+}
+
+static int https_url_ok(const char *url) {
+    if (!url || strncmp(url, "https://", 8) != 0) return 0;
+    for (const char *p = url; *p; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (c < 32 || c > 126) return 0;
+        if (c == ' ' || c == '"' || c == '\'' || c == '`' || c == '\\') return 0;
     }
     return 1;
 }
@@ -49,9 +97,8 @@ static int tag_ok(const char *tag) {
 static void on_check_update(GtkWidget *widget, gpointer data) {
     char *argv[] = {
         (char *)"curl", (char *)"-sS",
-        (char *)"-H", (char *)"User-Agent: ProxyBridge-Linux",
-        (char *)"-H", (char *)"Accept: application/vnd.github+json",
-        (char *)"https://api.github.com/repos/InterceptSuite/ProxyBridge/releases/latest",
+        (char *)"-H", (char *)"User-Agent: ProxyBridge-UpdateChecker",
+        (char *)UPD_FEED_URL,
         NULL
     };
     char *json = NULL;
@@ -59,7 +106,7 @@ static void on_check_update(GtkWidget *widget, gpointer data) {
     GError *spawn_err = NULL;
     int exit_code = 0;
 
-    // dont shell out with g_strdup_printf, and dont download+run deploy.sh as root anymore
+    // feed only, no deploy.sh. open the linux download/notes url in the browser
     if (!g_spawn_sync(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL,
                       &json, &curl_err, &exit_code, &spawn_err)) {
         show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Update check failed: %s",
@@ -75,37 +122,53 @@ static void on_check_update(GtkWidget *widget, gpointer data) {
         return;
     }
 
-    char *tag_name = extract_sub_json_str(json, "tag_name");
-    char *html_url = extract_sub_json_str(json, "html_url");
+    char *linux_obj = extract_platform_block(json, "linux");
     g_free(json);
     g_free(curl_err);
-
-    if (!tag_name || !tag_ok(tag_name)) {
-        show_message(GTK_WINDOW(window), GTK_MESSAGE_WARNING, "Could not parse version info.");
-        g_free(tag_name);
-        g_free(html_url);
+    if (!linux_obj) {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_WARNING, "Could not parse linux update info.");
         return;
     }
 
-    char *current_tag = g_strdup_printf("v%s", PROXYBRIDGE_VERSION);
-    if (strcmp(tag_name, current_tag) == 0) {
+    char *version = extract_sub_json_str(linux_obj, "version");
+    char *download = extract_sub_json_str(linux_obj, "download");
+    char *notes = extract_sub_json_str(linux_obj, "release_notes");
+    g_free(linux_obj);
+
+    if (!version || !version[0]) {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_WARNING, "Could not parse version info.");
+        g_free(version);
+        g_free(download);
+        g_free(notes);
+        return;
+    }
+
+    int cur[3], lat[3];
+    parse_ver(PROXYBRIDGE_VERSION, cur);
+    parse_ver(version, lat);
+    if (ver_cmp(lat, cur) <= 0) {
         show_message(GTK_WINDOW(window), GTK_MESSAGE_INFO, "You are using the latest version (%s).", PROXYBRIDGE_VERSION);
-    } else {
-        GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT,
-            GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
-            "Version %s is available (current %s).\nOpen the GitHub release page?", tag_name, PROXYBRIDGE_VERSION);
-        gtk_dialog_add_button(GTK_DIALOG(dialog), "Open Release Page", GTK_RESPONSE_ACCEPT);
-        gtk_dialog_add_button(GTK_DIALOG(dialog), "Close", GTK_RESPONSE_CANCEL);
-        int resp = gtk_dialog_run(GTK_DIALOG(dialog));
-        gtk_widget_destroy(dialog);
-        if (resp == GTK_RESPONSE_ACCEPT) {
-            char fallback[256];
-            const char *url = html_url;
-            if (!url || !url[0]) {
-                snprintf(fallback, sizeof(fallback),
-                    "https://github.com/InterceptSuite/ProxyBridge/releases/tag/%s", tag_name);
-                url = fallback;
-            }
+        g_free(version);
+        g_free(download);
+        g_free(notes);
+        return;
+    }
+
+    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT,
+        GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
+        "Version %s is available (current %s).\nOpen the download page in your browser?",
+        version, PROXYBRIDGE_VERSION);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "Open in Browser", GTK_RESPONSE_ACCEPT);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "Close", GTK_RESPONSE_CANCEL);
+    int resp = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    if (resp == GTK_RESPONSE_ACCEPT) {
+        const char *url = NULL;
+        if (https_url_ok(notes)) url = notes;
+        else if (https_url_ok(download)) url = download;
+        if (!url) {
+            show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "No safe https url in update feed.");
+        } else {
             GError *uri_err = NULL;
             if (!gtk_show_uri_on_window(GTK_WINDOW(window), url, GDK_CURRENT_TIME, &uri_err)) {
                 show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Could not open browser: %s",
@@ -114,9 +177,9 @@ static void on_check_update(GtkWidget *widget, gpointer data) {
             }
         }
     }
-    g_free(current_tag);
-    g_free(tag_name);
-    g_free(html_url);
+    g_free(version);
+    g_free(download);
+    g_free(notes);
 }
 
 static void on_about(GtkWidget *widget, gpointer data) {

--- a/Linux/gui/main.c
+++ b/Linux/gui/main.c
@@ -1,5 +1,4 @@
 #include "gui.h"
-#include <ctype.h>
 
 // widgets
 GtkWidget *window;
@@ -35,67 +34,53 @@ static void on_dns_proxy_toggled(GtkCheckMenuItem *item, gpointer data) {
     save_config();
 }
 
-static bool tag_name_is_safe(const char *tag) {
-    if (!tag || !tag[0]) return false;
+static int tag_ok(const char *tag) {
+    if (!tag || !tag[0]) return 0;
     for (const char *p = tag; *p; p++) {
-        unsigned char c = (unsigned char)*p;
-        if (!(isalnum(c) || c == '.' || c == '-' || c == '_'))
-            return false;
+        char c = *p;
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_')
+            continue;
+        return 0;
     }
-    return true;
+    return 1;
 }
 
-static gboolean fetch_latest_release_json(char **out_body) {
+static void on_check_update(GtkWidget *widget, gpointer data) {
     char *argv[] = {
-        (char *)"curl",
-        (char *)"-sS",
+        (char *)"curl", (char *)"-sS",
         (char *)"-H", (char *)"User-Agent: ProxyBridge-Linux",
         (char *)"-H", (char *)"Accept: application/vnd.github+json",
         (char *)"https://api.github.com/repos/InterceptSuite/ProxyBridge/releases/latest",
         NULL
     };
-    char *stdout_buf = NULL;
-    char *stderr_buf = NULL;
-    GError *error = NULL;
-    int exit_status = 0;
-    gboolean ok = g_spawn_sync(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL,
-                               &stdout_buf, &stderr_buf, &exit_status, &error);
-    if (!ok || exit_status != 0 || !stdout_buf || stdout_buf[0] == '\0') {
-        if (error) g_error_free(error);
-        g_free(stdout_buf);
-        g_free(stderr_buf);
-        return FALSE;
+    char *json = NULL;
+    char *curl_err = NULL;
+    GError *spawn_err = NULL;
+    int exit_code = 0;
+
+    // dont shell out with g_strdup_printf, and dont download+run deploy.sh as root anymore
+    if (!g_spawn_sync(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL,
+                      &json, &curl_err, &exit_code, &spawn_err)) {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Update check failed: %s",
+                     spawn_err ? spawn_err->message : "unknown");
+        if (spawn_err) g_error_free(spawn_err);
+        g_free(curl_err);
+        return;
     }
-    *out_body = stdout_buf;
-    g_free(stderr_buf);
-    return TRUE;
-}
-
-static void open_release_page(const char *html_url) {
-    if (!html_url || !html_url[0]) return;
-    GError *error = NULL;
-    if (!gtk_show_uri_on_window(GTK_WINDOW(window), html_url, GDK_CURRENT_TIME, &error)) {
-        show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR,
-                     "Could not open release page: %s", error ? error->message : "unknown error");
-        if (error) g_error_free(error);
-    }
-}
-
-static void on_check_update(GtkWidget *widget, gpointer data) {
-    (void)widget;
-    (void)data;
-
-    char *release_json = NULL;
-    if (!fetch_latest_release_json(&release_json)) {
-        show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Update check failed (could not reach GitHub).");
+    if (exit_code != 0 || !json || json[0] == '\0') {
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Update check failed (curl exit %d).", exit_code);
+        g_free(json);
+        g_free(curl_err);
         return;
     }
 
-    char *tag_name = extract_sub_json_str(release_json, "tag_name");
-    char *html_url = extract_sub_json_str(release_json, "html_url");
-    g_free(release_json);
+    char *tag_name = extract_sub_json_str(json, "tag_name");
+    char *html_url = extract_sub_json_str(json, "html_url");
+    g_free(json);
+    g_free(curl_err);
 
-    if (!tag_name || !tag_name_is_safe(tag_name)) {
+    if (!tag_name || !tag_ok(tag_name)) {
         show_message(GTK_WINDOW(window), GTK_MESSAGE_WARNING, "Could not parse version info.");
         g_free(tag_name);
         g_free(html_url);
@@ -104,28 +89,31 @@ static void on_check_update(GtkWidget *widget, gpointer data) {
 
     char *current_tag = g_strdup_printf("v%s", PROXYBRIDGE_VERSION);
     if (strcmp(tag_name, current_tag) == 0) {
-        show_message(GTK_WINDOW(window), GTK_MESSAGE_INFO,
-                     "You are using the latest version (%s).", PROXYBRIDGE_VERSION);
+        show_message(GTK_WINDOW(window), GTK_MESSAGE_INFO, "You are using the latest version (%s).", PROXYBRIDGE_VERSION);
     } else {
-        GtkWidget *dialog = gtk_message_dialog_new(
-            GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
-            "New version %s is available.\nCurrent: %s\n\nOpen the official GitHub release page to download?", tag_name, PROXYBRIDGE_VERSION);
+        GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT,
+            GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE,
+            "Version %s is available (current %s).\nOpen the GitHub release page?", tag_name, PROXYBRIDGE_VERSION);
         gtk_dialog_add_button(GTK_DIALOG(dialog), "Open Release Page", GTK_RESPONSE_ACCEPT);
         gtk_dialog_add_button(GTK_DIALOG(dialog), "Close", GTK_RESPONSE_CANCEL);
         int resp = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_destroy(dialog);
         if (resp == GTK_RESPONSE_ACCEPT) {
-            if (html_url && html_url[0])
-                open_release_page(html_url);
-            else {
-                char fallback[256];
+            char fallback[256];
+            const char *url = html_url;
+            if (!url || !url[0]) {
                 snprintf(fallback, sizeof(fallback),
-                         "https://github.com/InterceptSuite/ProxyBridge/releases/tag/%s", tag_name);
-                open_release_page(fallback);
+                    "https://github.com/InterceptSuite/ProxyBridge/releases/tag/%s", tag_name);
+                url = fallback;
+            }
+            GError *uri_err = NULL;
+            if (!gtk_show_uri_on_window(GTK_WINDOW(window), url, GDK_CURRENT_TIME, &uri_err)) {
+                show_message(GTK_WINDOW(window), GTK_MESSAGE_ERROR, "Could not open browser: %s",
+                             uri_err ? uri_err->message : "unknown");
+                if (uri_err) g_error_free(uri_err);
             }
         }
     }
-
     g_free(current_tag);
     g_free(tag_name);
     g_free(html_url);

--- a/Linux/gui/main.c
+++ b/Linux/gui/main.c
@@ -37,15 +37,27 @@ static void on_dns_proxy_toggled(GtkCheckMenuItem *item, gpointer data) {
 // same feed as windows/mac: https://download.interceptsuite.com/proxybridge.json
 #define UPD_FEED_URL "https://download.interceptsuite.com/proxybridge.json"
 
+// match "linux": { ... } as a key, not a random "linux" string value
 static char *extract_platform_block(const char *json, const char *platform) {
     char needle[64];
     snprintf(needle, sizeof(needle), "\"%s\"", platform);
-    char *p = strstr(json, needle);
-    if (!p) return NULL;
-    char *brace = strchr(p, '{');
+    size_t nlen = strlen(needle);
+    const char *p = json;
+    const char *key = NULL;
+    while ((p = strstr(p, needle)) != NULL) {
+        const char *after = p + nlen;
+        while (*after == ' ' || *after == '\t' || *after == '\n' || *after == '\r') after++;
+        if (*after == ':') {
+            key = p;
+            break;
+        }
+        p += nlen;
+    }
+    if (!key) return NULL;
+    const char *brace = strchr(key, '{');
     if (!brace) return NULL;
     int depth = 0;
-    for (char *q = brace; *q; q++) {
+    for (const char *q = brace; *q; q++) {
         if (*q == '{') depth++;
         else if (*q == '}') {
             depth--;

--- a/Linux/src/ProxyBridge.c
+++ b/Linux/src/ProxyBridge.c
@@ -1413,7 +1413,7 @@ static void* local_proxy_server(void *arg)
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
-    // localhost only - matches Windows/macOS relay posture; INADDR_ANY exposed LAN relay abuse
+    // loopback only, INADDR_ANY was reachable from the lan
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     addr.sin_port = htons(g_local_relay_port);
 

--- a/Linux/src/ProxyBridge.c
+++ b/Linux/src/ProxyBridge.c
@@ -1413,7 +1413,8 @@ static void* local_proxy_server(void *arg)
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = INADDR_ANY;
+    // localhost only - matches Windows/macOS relay posture; INADDR_ANY exposed LAN relay abuse
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     addr.sin_port = htons(g_local_relay_port);
 
     if (bind(listen_sock, (struct sockaddr *)&addr, sizeof(addr)) < 0)
@@ -1675,7 +1676,7 @@ static void* udp_relay_server(void *arg)
 
     memset(&local_addr, 0, sizeof(local_addr));
     local_addr.sin_family = AF_INET;
-    local_addr.sin_addr.s_addr = INADDR_ANY;
+    local_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     local_addr.sin_port = htons(LOCAL_UDP_RELAY_PORT);
 
     if (bind(udp_relay_socket, (struct sockaddr *)&local_addr, sizeof(local_addr)) < 0)


### PR DESCRIPTION
## Summary

Three Linux security fixes (+ update feed alignment):

1. Relay bind: TCP/UDP relay ports 34010 and 34011 used `INADDR_ANY`. Now `127.0.0.1` only, same idea as the other platforms.

2. Config perms: proxy creds in `/etc/proxybridge/config.ini` were default world readable. Dir `0700`, file `0600`, chmod on load for old installs.

3. GUI update: used to curl `deploy.sh` from raw github and run bash as root. Now reads `https://download.interceptsuite.com/proxybridge.json` (linux entry, same feed as mac/windows) and opens the release/download url in the browser via `gtk_show_uri_on_window`. No script download/exec.

Closes #211

## Test plan

- [ ] build linux gui + core on ubuntu/debian
- [ ] `ss -lntp` shows `127.0.0.1:34010` and `:34011` only
- [ ] save settings, `stat -c %a /etc/proxybridge/config.ini` is `600`
- [ ] About -> Check for Updates hits `proxybridge.json`, opens browser on newer linux version, no `deploy.sh` exec
