### PR TITLE
fix: evict stale port-decision cache entry when an ephemeral port is reused

### DIFF
--- a/Windows/src/ProxyBridge.c
+++ b/Windows/src/ProxyBridge.c
@@ -689,6 +689,13 @@ static DWORD WINAPI packet_processor(LPVOID arg)
                 UINT16 sp = ntohs(tcp_header->SrcPort);
                 UINT16 dp = ntohs(tcp_header->DstPort);
 
+                // Same ephemeral-port reuse problem as IPv4 below, and the decision
+                // bitmaps are shared by both stacks: a verdict cached for an IPv4
+                // connection must not be inherited by a new IPv6 connection that
+                // happens to reuse the port number, or vice versa.
+                if (tcp_header->Syn && !tcp_header->Ack && port_is_decided(sp))
+                    port_clear(sp);
+
                 if (port_is_decided(sp))
                 {
                     if (tcp_header->Fin || tcp_header->Rst) port_clear(sp);
@@ -1081,7 +1088,19 @@ static DWORD WINAPI packet_processor(LPVOID arg)
                 // process instead of a stale one (prevents wrong-app rule matching for
                 // up to PID_CACHE_TTL_MS after a port is recycled).
                 if (tcp_header->Syn && !tcp_header->Ack)
+                {
                     remove_cached_pid(ip_header->SrcAddr, sp, FALSE);
+
+                    // The cached rule decision belongs to the previous owner of this
+                    // port and has to go with it. FIN/RST is not a reliable eviction
+                    // trigger: server-initiated closes arrive on the inbound branch and
+                    // loopback/abortive teardowns never show up here at all, so a
+                    // DIRECT verdict can outlive the connection that produced it. The
+                    // next connection reusing the port would then hit the fast-path
+                    // above and go out unproxied without its own rule ever running.
+                    if (port_is_decided(sp))
+                        port_clear(sp);
+                }
 
                 if (port_is_decided(sp))
                 {


### PR DESCRIPTION
Fixes #206.

## Problem

The fast path caches a per-source-port rule decision in `port_decided_bitmap` / `port_direct_bitmap`. A cached DIRECT verdict is only evicted on an **outbound** FIN/RST, which is not a reliable end-of-life signal:

- server-initiated closes arrive on the inbound branch and never reach that code,
- abortive/loopback teardowns are not observed there either,
- and after `port_clear(sp)` on FIN/RST the same iteration falls through to `check_process_rule()` and re-caches DIRECT via `port_set_direct(sp)`, so even an observed teardown does not necessarily leave the entry cleared (thanks to @dentatli for spotting this one).

So a DIRECT verdict outlives the connection that produced it. When Windows recycles the ephemeral port to a different process, the new SYN hits the fast path, is sent unmodified, and that process's own rule never runs — traffic that should be proxied goes out direct. It accumulates with uptime: on my workstation the effect was invisible for the first hours and near-total after a day.

## Fix

Treat a fresh SYN (`Syn && !Ack`) as the ownership boundary and evict the cached decision there, right next to the existing `remove_cached_pid()` call that already handles exactly this scenario for the PID cache. Applied to both stacks, because IPv4 and IPv6 share the same decision bitmaps and would otherwise inherit each other's verdicts.

Cost is one bitmap test plus one clear on new connections only; the steady-state fast path for established flows is untouched.

## Verification

Built with MSVC 2022 + WinDivert 2.2.2-A, run on Windows 11 for ~63 hours without a restart:

- exit IP stable across 757 probes (5-minute interval), zero direct leaks,
- instrumented build: cached-decision count stayed bounded instead of growing to thousands per hour as before,
- @hewzhew independently reproduced the bug and rebased this commit onto current `dev` — identical patch ID, clean build.

## Relation to #209

Complementary, not overlapping. #209 is about flow identity being keyed on `src_port` alone in `connection_hash_table`; this change only bounds how long a decision may live. Both are worth having, and neither depends on the other.

## AI-assisted code disclosure

Per CONTRIBUTING § AI-Generated Code: this patch was written with Claude Opus under my direction, instrumentation and testing. It is 2 hunks / ~15 lines, reuses the existing eviction point rather than adding new state or abstractions, and I have read and understood every line of it. Happy to iterate on placement or wording of the comments if you would prefer them shorter.

### Checklist

- [x] Code builds without errors (MSVC 2022, Windows x64 core DLL)
- [x] No merge conflicts
- [x] One focused change, commit signed off (`git commit -s`)
- [x] Follows existing style of the surrounding fast-path code
- [ ] Documentation — no user-facing change, nothing to update
