### PR TITLE
fix: forward redirected DIRECT flows without a proxy

### DIFF
--- a/Windows/src/core/pb_internal.h
+++ b/Windows/src/core/pb_internal.h
@@ -89,6 +89,7 @@ typedef struct CONNECTION_INFO {
     BOOL   is_tracked;
     ULONGLONG last_activity;
     UINT32 proxy_config_id;
+    RuleAction action;            // explicit: config id 0 is also "first proxy", not DIRECT
     BOOL   is_ipv6;
     UINT8  src_ip6[16];        // raw IPv6 src (only valid when is_ipv6)
     UINT8  orig_dest_ip6[16];  // raw IPv6 dest (only valid when is_ipv6)
@@ -103,6 +104,7 @@ typedef struct {
     UINT32 orig_dest_ip;
     UINT16 orig_dest_port;
     UINT32 proxy_config_id;
+    RuleAction action;
     BOOL   is_ipv6;
     UINT8  orig_dest_ip6[16];
 } CONNECTION_CONFIG;
@@ -295,9 +297,17 @@ UINT32 rev_hash_v4(UINT32 dest_ip, UINT16 dest_port);
 UINT32 rev_hash_v6(const UINT8 dest_ip6[16], UINT16 dest_port);
 void rev_insert(CONNECTION_INFO *c);
 void rev_unlink(CONNECTION_INFO *c);
-void add_connection(UINT16 src_port, BOOL is_udp, UINT32 src_ip, UINT32 dest_ip, UINT16 dest_port, UINT32 proxy_config_id);
-BOOL get_connection_full_v6(UINT16 src_port, BOOL is_udp, UINT8 dest_ip6[16], UINT16 *dest_port, UINT32 *proxy_config_id);
-BOOL find_v6_udp_sender(const UINT8 orig_dest_ip6[16], UINT16 orig_dest_port, UINT8 src_ip6[16], UINT16 *src_port);
+void add_connection(UINT16 src_port, BOOL is_udp, UINT32 src_ip, UINT32 dest_ip,
+                    UINT16 dest_port, UINT32 proxy_config_id, RuleAction action);
+void add_connection_v6(UINT16 src_port, BOOL is_udp, const UINT8 src_ip6[16],
+                       const UINT8 dest_ip6[16], UINT16 dest_port,
+                       UINT32 proxy_config_id, RuleAction action);
+BOOL get_connection_full_v6(UINT16 src_port, BOOL is_udp, UINT8 dest_ip6[16],
+                            UINT16 *dest_port, UINT32 *proxy_config_id, RuleAction *action);
+BOOL find_udp_sender(UINT32 orig_dest_ip, UINT16 orig_dest_port, RuleAction action,
+                     UINT32 *src_ip, UINT16 *src_port);
+BOOL find_v6_udp_sender(const UINT8 orig_dest_ip6[16], UINT16 orig_dest_port,
+                        RuleAction action, UINT8 src_ip6[16], UINT16 *src_port);
 BOOL get_connection(UINT16 src_port, BOOL is_udp, UINT32 *dest_ip, UINT16 *dest_port);
 BOOL get_connection_full(UINT16 src_port, BOOL is_udp, UINT32 *dest_ip, UINT16 *dest_port, UINT32 *proxy_config_id);
 UINT32 get_connection_proxy_id(UINT16 src_port, BOOL is_udp);
@@ -330,5 +340,7 @@ void pb_driver_sync_config(void);  // re-push config after a setting change (e.g
 BOOL pb_driver_orig_dest(SOCKET s, UINT32 *ip, UINT16 *port, DWORD *pid);
 BOOL pb_driver_orig_dest6(SOCKET s, UINT8 ip6[16], UINT16 *port, DWORD *pid);
 BOOL pb_driver_udp_orig(UINT32 src_ip, UINT16 src_port, UINT32 *ip, UINT16 *port, DWORD *pid);
+BOOL pb_driver_udp_orig6(const UINT8 src_ip6[16], UINT16 src_port,
+                         UINT8 ip6[16], UINT16 *port, DWORD *pid);
 
 #endif // PB_INTERNAL_H

--- a/Windows/src/driver/pb_driver.c
+++ b/Windows/src/driver/pb_driver.c
@@ -332,3 +332,17 @@ BOOL pb_driver_udp_orig(UINT32 src_ip, UINT16 src_port, UINT32 *ip, UINT16 *port
     if (pid) *pid = q.pid;
     return TRUE;
 }
+
+// Relay-side (UDP IPv6): recover a redirected datagram's original dest by its source.
+BOOL pb_driver_udp_orig6(const UINT8 src_ip6[16], UINT16 src_port,
+                         UINT8 ip6[16], UINT16 *port, DWORD *pid)
+{
+    if (g_drv == INVALID_HANDLE_VALUE) return FALSE;
+    PBDRV_UDP_QUERY q; memset(&q, 0, sizeof(q));
+    q.family = AF_INET6; q.srcPort = src_port;
+    memcpy(q.srcV6, src_ip6, 16);
+    if (!pbdrv_udp_query(g_drv, &q) || !q.found) return FALSE;
+    memcpy(ip6, q.origV6, 16); *port = q.origPort;
+    if (pid) *pid = q.pid;
+    return TRUE;
+}

--- a/Windows/src/relay/pb_conntrack.c
+++ b/Windows/src/relay/pb_conntrack.c
@@ -36,55 +36,74 @@ void rev_unlink(CONNECTION_INFO *c)
     c->rev_next = NULL;
 }
 
-void add_connection(UINT16 src_port, BOOL is_udp, UINT32 src_ip, UINT32 dest_ip, UINT16 dest_port, UINT32 proxy_config_id)
+// Find or allocate an entry for the source tuple. Caller holds `lock` exclusively.
+static CONNECTION_INFO *upsert_connection(UINT16 src_port, BOOL is_udp, BOOL is_ipv6)
 {
-    AcquireSRWLockExclusive(&lock);
-
     int hash = src_port % CONNECTION_HASH_SIZE;
-    CONNECTION_INFO *existing = connection_hash_table[hash];
-
-    // Match on (port, protocol, family): a TCP and a UDP flow - or an IPv4 and an
-    // IPv6 flow - may legitimately share a numeric local port at the same time.
-    while (existing != NULL) {
-        if (existing->src_port == src_port && existing->is_udp == is_udp && !existing->is_ipv6) {
-            rev_unlink(existing);   // dest may change (port reuse) - re-key the reverse index
-            existing->is_ipv6 = FALSE;
-            existing->src_ip = src_ip;
-            existing->orig_dest_ip = dest_ip;
-            existing->orig_dest_port = dest_port;
-            existing->proxy_config_id = proxy_config_id;
-            existing->is_tracked = TRUE;
-            existing->last_activity = GetTickCount64();
-            rev_insert(existing);
-            ReleaseSRWLockExclusive(&lock);
-            return;
+    for (CONNECTION_INFO *conn = connection_hash_table[hash]; conn != NULL; conn = conn->next) {
+        if (conn->src_port == src_port && conn->is_udp == is_udp &&
+            conn->is_ipv6 == is_ipv6) {
+            rev_unlink(conn);
+            return conn;
         }
-        existing = existing->next;
     }
 
     CONNECTION_INFO *conn = (CONNECTION_INFO *)calloc(1, sizeof(CONNECTION_INFO));
+    if (conn != NULL) {
+        conn->src_port = src_port;
+        conn->is_udp = is_udp;
+        conn->is_ipv6 = is_ipv6;
+        conn->next = connection_hash_table[hash];
+        connection_hash_table[hash] = conn;
+    }
+    return conn;
+}
+
+void add_connection(UINT16 src_port, BOOL is_udp, UINT32 src_ip, UINT32 dest_ip,
+                    UINT16 dest_port, UINT32 proxy_config_id, RuleAction action)
+{
+    AcquireSRWLockExclusive(&lock);
+    CONNECTION_INFO *conn = upsert_connection(src_port, is_udp, FALSE);
     if (conn == NULL) {
         ReleaseSRWLockExclusive(&lock);
         return;
     }
 
-    conn->src_port = src_port;
-    conn->is_udp = is_udp;
     conn->src_ip = src_ip;
     conn->orig_dest_ip = dest_ip;
     conn->orig_dest_port = dest_port;
     conn->proxy_config_id = proxy_config_id;
+    conn->action = action;
     conn->is_tracked = TRUE;
-    conn->is_ipv6 = FALSE;
     conn->last_activity = GetTickCount64();
-
-    conn->next = connection_hash_table[hash];
-    connection_hash_table[hash] = conn;
     rev_insert(conn);
     ReleaseSRWLockExclusive(&lock);
 }
 
-BOOL get_connection_full_v6(UINT16 src_port, BOOL is_udp, UINT8 dest_ip6[16], UINT16 *dest_port, UINT32 *proxy_config_id)
+void add_connection_v6(UINT16 src_port, BOOL is_udp, const UINT8 src_ip6[16],
+                       const UINT8 dest_ip6[16], UINT16 dest_port,
+                       UINT32 proxy_config_id, RuleAction action)
+{
+    AcquireSRWLockExclusive(&lock);
+    CONNECTION_INFO *conn = upsert_connection(src_port, is_udp, TRUE);
+    if (conn == NULL) {
+        ReleaseSRWLockExclusive(&lock);
+        return;
+    }
+
+    memcpy(conn->src_ip6, src_ip6, 16);
+    memcpy(conn->orig_dest_ip6, dest_ip6, 16);
+    conn->orig_dest_port = dest_port;
+    conn->proxy_config_id = proxy_config_id;
+    conn->action = action;
+    conn->is_tracked = TRUE;
+    conn->last_activity = GetTickCount64();
+    rev_insert(conn);
+    ReleaseSRWLockExclusive(&lock);
+}
+
+BOOL get_connection_full_v6(UINT16 src_port, BOOL is_udp, UINT8 dest_ip6[16],
+                            UINT16 *dest_port, UINT32 *proxy_config_id, RuleAction *action)
 {
     BOOL found = FALSE;
     AcquireSRWLockShared(&lock);
@@ -95,6 +114,7 @@ BOOL get_connection_full_v6(UINT16 src_port, BOOL is_udp, UINT8 dest_ip6[16], UI
             memcpy(dest_ip6, conn->orig_dest_ip6, 16);
             *dest_port = conn->orig_dest_port;
             if (proxy_config_id != NULL) *proxy_config_id = conn->proxy_config_id;
+            if (action != NULL) *action = conn->action;
             InterlockedExchange64((LONGLONG volatile*)&conn->last_activity, (LONGLONG)GetTickCount64());
             found = TRUE;
             break;
@@ -105,24 +125,62 @@ BOOL get_connection_full_v6(UINT16 src_port, BOOL is_udp, UINT8 dest_ip6[16], UI
     return found;
 }
 
-// Reverse lookup for IPv6 UDP relay responses: find src addr+port by orig dest ip6+port
-BOOL find_v6_udp_sender(const UINT8 orig_dest_ip6[16], UINT16 orig_dest_port, UINT8 src_ip6[16], UINT16 *src_port)
+// Reverse lookup for an IPv4 UDP response. The action is part of the key because DIRECT
+// datagrams use the listener socket while proxied replies arrive on a per-proxy socket.
+BOOL find_udp_sender(UINT32 orig_dest_ip, UINT16 orig_dest_port, RuleAction action,
+                     UINT32 *src_ip, UINT16 *src_port)
 {
     BOOL found = FALSE;
     ULONGLONG best = 0;
+    CONNECTION_INFO *winner = NULL;
+    AcquireSRWLockShared(&lock);
+    for (CONNECTION_INFO *conn = connection_rev_table[rev_hash_v4(orig_dest_ip, orig_dest_port)];
+         conn != NULL; conn = conn->rev_next) {
+        if (conn->is_udp && !conn->is_ipv6 && conn->action == action &&
+            conn->orig_dest_ip == orig_dest_ip && conn->orig_dest_port == orig_dest_port) {
+            if (!found || conn->last_activity > best) {
+                *src_ip = conn->src_ip;
+                *src_port = conn->src_port;
+                best = conn->last_activity;
+                found = TRUE;
+                winner = conn;
+            }
+        }
+    }
+    if (winner != NULL) {
+        InterlockedExchange64((LONGLONG volatile *)&winner->last_activity,
+                              (LONGLONG)GetTickCount64());
+    }
+    ReleaseSRWLockShared(&lock);
+    return found;
+}
+
+// Reverse lookup for an IPv6 UDP response: find its application source endpoint.
+BOOL find_v6_udp_sender(const UINT8 orig_dest_ip6[16], UINT16 orig_dest_port,
+                        RuleAction action, UINT8 src_ip6[16], UINT16 *src_port)
+{
+    BOOL found = FALSE;
+    ULONGLONG best = 0;
+    CONNECTION_INFO *winner = NULL;
     AcquireSRWLockShared(&lock);
     // O(1): only the reverse bucket for this (dest ip6, dest port).
     for (CONNECTION_INFO *conn = connection_rev_table[rev_hash_v6(orig_dest_ip6, orig_dest_port)];
          conn != NULL; conn = conn->rev_next) {
-        if (conn->is_udp && conn->is_ipv6 && conn->orig_dest_port == orig_dest_port &&
+        if (conn->is_udp && conn->is_ipv6 && conn->action == action &&
+            conn->orig_dest_port == orig_dest_port &&
             memcmp(conn->orig_dest_ip6, orig_dest_ip6, 16) == 0) {
             if (!found || conn->last_activity > best) {
                 memcpy(src_ip6, conn->src_ip6, 16);
                 *src_port = conn->src_port;
                 best = conn->last_activity;
                 found = TRUE;
+                winner = conn;
             }
         }
+    }
+    if (winner != NULL) {
+        InterlockedExchange64((LONGLONG volatile *)&winner->last_activity,
+                              (LONGLONG)GetTickCount64());
     }
     ReleaseSRWLockShared(&lock);
     return found;
@@ -418,4 +476,3 @@ void clear_logged_connections(void)
 
     ReleaseSRWLockExclusive(&lock);
 }
-

--- a/Windows/src/relay/pb_relay_tcp.c
+++ b/Windows/src/relay/pb_relay_tcp.c
@@ -102,6 +102,7 @@ DWORD WINAPI local_proxy_server(LPVOID arg)
                 {
                     conn_config->client_socket = client_sock;
                     conn_config->is_ipv6 = FALSE;
+                    conn_config->action = RULE_ACTION_PROXY;
 
                     BOOL have_dest;
                     if (g_use_wfp_driver)
@@ -119,6 +120,7 @@ DWORD WINAPI local_proxy_server(LPVOID arg)
                             if (get_process_name_from_pid(pid, pname, sizeof(pname)))
                                 act = match_rule(pname, conn_config->orig_dest_ip, conn_config->orig_dest_port, FALSE, &cfg);
                             conn_config->proxy_config_id = cfg;
+                            conn_config->action = act;
                             struct in_addr da; da.S_un.S_addr = conn_config->orig_dest_ip;
                             log_message("[RELAY] accepted redirect: pid=%lu dest=%s:%u action=%d cfg=%u",
                                         pid, inet_ntoa(da), conn_config->orig_dest_port, act, cfg);
@@ -162,6 +164,7 @@ DWORD WINAPI local_proxy_server(LPVOID arg)
                 {
                     conn_config->client_socket = client_sock6;
                     conn_config->is_ipv6 = TRUE;
+                    conn_config->action = RULE_ACTION_PROXY;
 
                     BOOL have_dest6;
                     if (g_use_wfp_driver)
@@ -177,6 +180,7 @@ DWORD WINAPI local_proxy_server(LPVOID arg)
                             if (get_process_name_from_pid(pid, pname, sizeof(pname)))
                                 act = match_rule_v6(pname, conn_config->orig_dest_ip6, conn_config->orig_dest_port, FALSE, &cfg);
                             conn_config->proxy_config_id = cfg;
+                            conn_config->action = act;
                             pb_report_connection(pid, NULL, TRUE, 0, conn_config->orig_dest_ip6,
                                                  conn_config->orig_dest_port, act, cfg, FALSE);
                             if (act == RULE_ACTION_BLOCK) have_dest6 = FALSE;
@@ -185,8 +189,10 @@ DWORD WINAPI local_proxy_server(LPVOID arg)
                     else
                     {
                         UINT16 client_port = ntohs(client_addr6.sin6_port);
-                        have_dest6 = get_connection_full_v6(client_port, FALSE, conn_config->orig_dest_ip6,
-                                                            &conn_config->orig_dest_port, &conn_config->proxy_config_id);
+                        have_dest6 = get_connection_full_v6(
+                            client_port, FALSE, conn_config->orig_dest_ip6,
+                            &conn_config->orig_dest_port, &conn_config->proxy_config_id,
+                            &conn_config->action);
                     }
                     if (have_dest6)
                     {
@@ -211,39 +217,20 @@ DWORD WINAPI connection_handler(LPVOID arg)
 {
     CONNECTION_CONFIG *config = (CONNECTION_CONFIG *)arg;
     SOCKET client_sock = config->client_socket;
-    UINT32 dest_ip = config->orig_dest_ip;
+    BOOL is_ipv6 = config->is_ipv6;
+    UINT32 dest_ip = is_ipv6 ? 0 : config->orig_dest_ip;
     UINT16 dest_port = config->orig_dest_port;
     UINT32 proxy_config_id = config->proxy_config_id;
-    BOOL is_ipv6 = config->is_ipv6;
+    RuleAction action = config->action;
     UINT8 dest_ip6[16];
     if (is_ipv6) memcpy(dest_ip6, config->orig_dest_ip6, 16);
-    SOCKET socks_sock;
-    struct sockaddr_in socks_addr;
+    SOCKET upstream_sock = INVALID_SOCKET;
 
     free(config);
 
-    // Snapshot the proxy config so this thread is immune to a concurrent Edit/Delete while it
-    // uses the settings across the (blocking) SOCKS5/HTTP handshake below.
-    PROXY_CONFIG proxy_snapshot;
-    PROXY_CONFIG *proxy = &proxy_snapshot;
-    if (!find_proxy_config_copy(proxy_config_id, &proxy_snapshot) ||
-        proxy->host[0] == '\0' || proxy->port == 0)
-    {
-        log_message("[RELAY] No proxy config (id=%u) - dropping connection", proxy_config_id);
-        closesocket(client_sock);
-        return 1;
-    }
-
-    // Connect to proxy, use cached resolved IP to avoid DNS per connection
-    UINT32 proxy_ip = proxy->resolved_ip ? proxy->resolved_ip : resolve_hostname(proxy->host);
-    if (proxy_ip == 0)
-    {
-        closesocket(client_sock);
-        return 1;
-    }
-
-    socks_sock = socket(AF_INET, SOCK_STREAM, 0);
-    if (socks_sock == INVALID_SOCKET)
+    int upstream_family = (action == RULE_ACTION_DIRECT && is_ipv6) ? AF_INET6 : AF_INET;
+    upstream_sock = socket(upstream_family, SOCK_STREAM, IPPROTO_TCP);
+    if (upstream_sock == INVALID_SOCKET)
     {
         log_message("Socket creation failed (%d)", WSAGetLastError());
         closesocket(client_sock);
@@ -256,66 +243,133 @@ DWORD WINAPI connection_handler(LPVOID arg)
     // the proxy's receive window fills up, which stalls the relay loop and
     // triggers TCP flow-control on the client side → massive upload throughput
     // loss.  4 MB gives plenty of headroom even at high bitrates / high RTT.
-    configure_tcp_socket(socks_sock, 4194304, 30000);  // 4 MB – proxy connection
+    configure_tcp_socket(upstream_sock, 4194304, 30000);  // 4 MB - upstream connection
     configure_tcp_socket(client_sock, 4194304, 30000); // 4 MB – app connection
 
-    memset(&socks_addr, 0, sizeof(socks_addr));
-    socks_addr.sin_family = AF_INET;
-    socks_addr.sin_addr.s_addr = proxy_ip;
-    socks_addr.sin_port = htons(proxy->port);
-
-    if (connect(socks_sock, (struct sockaddr *)&socks_addr, sizeof(socks_addr)) == SOCKET_ERROR)
-    {
-        log_message("[RELAY] Failed to connect to proxy %s:%d (%d)", proxy->host, proxy->port, WSAGetLastError());
-        closesocket(client_sock);
-        closesocket(socks_sock);
-        return 0;
-    }
-
-    if (proxy->type == PROXY_TYPE_SOCKS5)
+    if (action == RULE_ACTION_DIRECT)
     {
         int rc;
-        char cached_domain[256];
-        // Per-config: only hand the hostname to the proxy (socks5h) when this config
-        // opts in; otherwise send the locally-resolved IP (socks5).
         if (is_ipv6)
         {
-            if (proxy->send_domain_to_proxy && dns_cache_lookup_v6(dest_ip6, cached_domain, sizeof(cached_domain)))
-                rc = socks5_connect_domain(socks_sock, cached_domain, dest_port, proxy);
-            else
-                rc = socks5_connect_v6(socks_sock, dest_ip6, dest_port, proxy);
+            struct sockaddr_in6 direct_addr6;
+            memset(&direct_addr6, 0, sizeof(direct_addr6));
+            direct_addr6.sin6_family = AF_INET6;
+            memcpy(&direct_addr6.sin6_addr, dest_ip6, 16);
+            direct_addr6.sin6_port = htons(dest_port);
+            rc = connect(upstream_sock, (struct sockaddr *)&direct_addr6, sizeof(direct_addr6));
         }
         else
         {
-            if (proxy->send_domain_to_proxy && dns_cache_lookup(dest_ip, cached_domain, sizeof(cached_domain)))
-                rc = socks5_connect_domain(socks_sock, cached_domain, dest_port, proxy);
-            else
-                rc = socks5_connect(socks_sock, dest_ip, dest_port, proxy);
+            struct sockaddr_in direct_addr;
+            memset(&direct_addr, 0, sizeof(direct_addr));
+            direct_addr.sin_family = AF_INET;
+            direct_addr.sin_addr.s_addr = dest_ip;
+            direct_addr.sin_port = htons(dest_port);
+            rc = connect(upstream_sock, (struct sockaddr *)&direct_addr, sizeof(direct_addr));
         }
-        if (rc != 0)
+        if (rc == SOCKET_ERROR)
         {
+            log_message("[RELAY] Direct connect to original destination failed (%d)",
+                        WSAGetLastError());
             closesocket(client_sock);
-            closesocket(socks_sock);
+            closesocket(upstream_sock);
             return 0;
         }
     }
-    else if (proxy->type == PROXY_TYPE_HTTP)
+    else
     {
-        int rc = is_ipv6
-            ? http_connect_v6(socks_sock, dest_ip6, dest_port, proxy)
-            : http_connect(socks_sock, dest_ip, dest_port, proxy);
-        if (rc != 0)
+        // Snapshot the proxy config so this thread is immune to a concurrent Edit/Delete while
+        // it uses the settings across the (blocking) SOCKS5/HTTP handshake below.
+        PROXY_CONFIG proxy_snapshot;
+        PROXY_CONFIG *proxy = &proxy_snapshot;
+        if (!find_proxy_config_copy(proxy_config_id, &proxy_snapshot) ||
+            proxy->host[0] == '\0' || proxy->port == 0)
+        {
+            log_message("[RELAY] No proxy config (id=%u) - dropping connection", proxy_config_id);
+            closesocket(client_sock);
+            closesocket(upstream_sock);
+            return 1;
+        }
+
+        // Connect to proxy, use cached resolved IP to avoid DNS per connection.
+        UINT32 proxy_ip = proxy->resolved_ip ? proxy->resolved_ip : resolve_hostname(proxy->host);
+        if (proxy_ip == 0)
         {
             closesocket(client_sock);
-            closesocket(socks_sock);
+            closesocket(upstream_sock);
+            return 1;
+        }
+
+        struct sockaddr_in proxy_addr;
+        memset(&proxy_addr, 0, sizeof(proxy_addr));
+        proxy_addr.sin_family = AF_INET;
+        proxy_addr.sin_addr.s_addr = proxy_ip;
+        proxy_addr.sin_port = htons(proxy->port);
+        if (connect(upstream_sock, (struct sockaddr *)&proxy_addr,
+                    sizeof(proxy_addr)) == SOCKET_ERROR)
+        {
+            log_message("[RELAY] Failed to connect to proxy %s:%d (%d)",
+                        proxy->host, proxy->port, WSAGetLastError());
+            closesocket(client_sock);
+            closesocket(upstream_sock);
             return 0;
+        }
+
+        if (proxy->type == PROXY_TYPE_SOCKS5)
+        {
+            int rc;
+            char cached_domain[256];
+            // Per-config: only hand the hostname to the proxy (socks5h) when this config
+            // opts in; otherwise send the locally-resolved IP (socks5).
+            if (is_ipv6)
+            {
+                if (proxy->send_domain_to_proxy &&
+                    dns_cache_lookup_v6(dest_ip6, cached_domain, sizeof(cached_domain)))
+                {
+                    rc = socks5_connect_domain(upstream_sock, cached_domain, dest_port, proxy);
+                }
+                else
+                {
+                    rc = socks5_connect_v6(upstream_sock, dest_ip6, dest_port, proxy);
+                }
+            }
+            else
+            {
+                if (proxy->send_domain_to_proxy &&
+                    dns_cache_lookup(dest_ip, cached_domain, sizeof(cached_domain)))
+                {
+                    rc = socks5_connect_domain(upstream_sock, cached_domain, dest_port, proxy);
+                }
+                else
+                {
+                    rc = socks5_connect(upstream_sock, dest_ip, dest_port, proxy);
+                }
+            }
+            if (rc != 0)
+            {
+                closesocket(client_sock);
+                closesocket(upstream_sock);
+                return 0;
+            }
+        }
+        else if (proxy->type == PROXY_TYPE_HTTP)
+        {
+            int rc = is_ipv6
+                ? http_connect_v6(upstream_sock, dest_ip6, dest_port, proxy)
+                : http_connect(upstream_sock, dest_ip, dest_port, proxy);
+            if (rc != 0)
+            {
+                closesocket(client_sock);
+                closesocket(upstream_sock);
+                return 0;
+            }
         }
     }
 
     // Disable timeout for data transfer phase
     DWORD zero_timeout = 0;
-    setsockopt(socks_sock, SOL_SOCKET, SO_RCVTIMEO, (char*)&zero_timeout, sizeof(zero_timeout));
-    setsockopt(socks_sock, SOL_SOCKET, SO_SNDTIMEO, (char*)&zero_timeout, sizeof(zero_timeout));
+    setsockopt(upstream_sock, SOL_SOCKET, SO_RCVTIMEO, (char*)&zero_timeout, sizeof(zero_timeout));
+    setsockopt(upstream_sock, SOL_SOCKET, SO_SNDTIMEO, (char*)&zero_timeout, sizeof(zero_timeout));
     setsockopt(client_sock, SOL_SOCKET, SO_RCVTIMEO, (char*)&zero_timeout, sizeof(zero_timeout));
     setsockopt(client_sock, SOL_SOCKET, SO_SNDTIMEO, (char*)&zero_timeout, sizeof(zero_timeout));
 
@@ -325,7 +379,8 @@ DWORD WINAPI connection_handler(LPVOID arg)
     keepalive_settings.keepalivetime = 300000;      // 5 minutes in milliseconds
     keepalive_settings.keepaliveinterval = 1000;    // 1 second interval
     DWORD bytes_returned = 0;
-    WSAIoctl(socks_sock, SIO_KEEPALIVE_VALS, &keepalive_settings, sizeof(keepalive_settings), NULL, 0, &bytes_returned, NULL, NULL);
+    WSAIoctl(upstream_sock, SIO_KEEPALIVE_VALS, &keepalive_settings,
+             sizeof(keepalive_settings), NULL, 0, &bytes_returned, NULL, NULL);
     WSAIoctl(client_sock, SIO_KEEPALIVE_VALS, &keepalive_settings, sizeof(keepalive_settings), NULL, 0, &bytes_returned, NULL, NULL);
 
     TRANSFER_CONFIG *transfer_config = (TRANSFER_CONFIG *)malloc(sizeof(TRANSFER_CONFIG));
@@ -334,12 +389,12 @@ DWORD WINAPI connection_handler(LPVOID arg)
     {
         log_message("Memory allocation failed for transfer_config");
         closesocket(client_sock);
-        closesocket(socks_sock);
+        closesocket(upstream_sock);
         return 0;
     }
 
     transfer_config->from_socket = client_sock;
-    transfer_config->to_socket = socks_sock;
+    transfer_config->to_socket = upstream_sock;
 
     // both transfer in current thread
     transfer_handler((LPVOID)transfer_config);

--- a/Windows/src/relay/pb_relay_udp.c
+++ b/Windows/src/relay/pb_relay_udp.c
@@ -166,31 +166,81 @@ DWORD WINAPI udp_relay_server(LPVOID arg)
                 UINT32 dest_ip = 0;
                 UINT16 dest_port = 0;
                 UINT32 proxy_config_id = 0;
-                BOOL have_udp;
+                RuleAction action = RULE_ACTION_PROXY;
+                BOOL have_udp = FALSE;
 
                 if (g_use_wfp_driver)
                 {
-                    // Original dest from the driver's UDP map; feed the reverse index so the
-                    // proxy-reply path below routes replies back to this client unchanged.
+                    // A mapped source is an application datagram. If there is no driver mapping,
+                    // this may instead be a reply to a DIRECT datagram sent from this socket.
                     DWORD pid = 0;
                     have_udp = pb_driver_udp_orig(from_addr.sin_addr.s_addr, from_port, &dest_ip, &dest_port, &pid);
                     if (have_udp)
                     {
                         char pname[MAX_PROCESS_NAME];
-                        RuleAction act = RULE_ACTION_PROXY;
-                        if (get_process_name_from_pid(pid, pname, sizeof(pname)))
-                            act = match_rule(pname, dest_ip, dest_port, TRUE, &proxy_config_id);
-                        pb_report_connection(pid, NULL, FALSE, dest_ip, NULL, dest_port, act, proxy_config_id, TRUE);
-                        if (act == RULE_ACTION_PROXY)
-                            add_connection(from_port, TRUE, from_addr.sin_addr.s_addr, dest_ip, dest_port, proxy_config_id);
-                        else
+                        if (get_process_name_from_pid(pid, pname, sizeof(pname))) {
+                            action = match_rule(pname, dest_ip, dest_port, TRUE, &proxy_config_id);
+                        }
+                        pb_report_connection(pid, NULL, FALSE, dest_ip, NULL, dest_port,
+                                             action, proxy_config_id, TRUE);
+                        if (action == RULE_ACTION_BLOCK)
+                        {
+                            remove_connection(from_port, TRUE, FALSE);
                             have_udp = FALSE;
+                        }
+                        else
+                        {
+                            add_connection(from_port, TRUE, from_addr.sin_addr.s_addr, dest_ip,
+                                           dest_port, proxy_config_id, action);
+                        }
+                    }
+                    else
+                    {
+                        UINT32 target_ip = 0;
+                        UINT16 target_port = 0;
+                        if (find_udp_sender(from_addr.sin_addr.s_addr, from_port,
+                                            RULE_ACTION_DIRECT, &target_ip, &target_port))
+                        {
+                            if (from_port == 53) {
+                                snoop_dns_response(recv_buf, recv_len);
+                            }
+                            struct sockaddr_in target_addr;
+                            memset(&target_addr, 0, sizeof(target_addr));
+                            target_addr.sin_family = AF_INET;
+                            target_addr.sin_addr.s_addr = target_ip;
+                            target_addr.sin_port = htons(target_port);
+                            if (sendto(udp_relay_socket, (char*)recv_buf, recv_len, 0,
+                                       (struct sockaddr *)&target_addr,
+                                       sizeof(target_addr)) == SOCKET_ERROR)
+                            {
+                                log_message("[UDP RELAY] Direct response to client port %d "
+                                            "failed: %d",
+                                            target_port, WSAGetLastError());
+                            }
+                        }
                     }
                 }
                 else
                 {
                     have_udp = get_connection(from_port, TRUE, &dest_ip, &dest_port);
                     if (have_udp) proxy_config_id = get_connection_proxy_id(from_port, TRUE);
+                }
+
+                if (have_udp && action == RULE_ACTION_DIRECT)
+                {
+                    struct sockaddr_in direct_addr;
+                    memset(&direct_addr, 0, sizeof(direct_addr));
+                    direct_addr.sin_family = AF_INET;
+                    direct_addr.sin_addr.s_addr = dest_ip;
+                    direct_addr.sin_port = htons(dest_port);
+                    if (sendto(udp_relay_socket, (char*)recv_buf, recv_len, 0,
+                               (struct sockaddr *)&direct_addr,
+                               sizeof(direct_addr)) == SOCKET_ERROR)
+                    {
+                        log_message("[UDP RELAY] Direct send to port %d failed: %d",
+                                    dest_port, WSAGetLastError());
+                    }
+                    have_udp = FALSE;
                 }
 
                 if (have_udp)
@@ -302,39 +352,10 @@ DWORD WINAPI udp_relay_server(LPVOID arg)
                     if (g_use_wfp_driver && src_port == 53 && recv_len > 10)
                         snoop_dns_response(&recv_buf[10], recv_len - 10);
 
-                    BOOL found = FALSE;
                     UINT32 target_ip = 0;
                     UINT16 target_port = 0;
-                    CONNECTION_INFO *winner_conn = NULL;
-
-                    AcquireSRWLockShared(&lock);
-                    ULONGLONG best_activity = 0;
-                    // O(1): only the reverse bucket for this (dest ip, dest port) - not the
-                    // whole table - then pick the most-recently-active matching client.
-                    for (CONNECTION_INFO *conn = connection_rev_table[rev_hash_v4(src_ip, src_port)];
-                         conn != NULL; conn = conn->rev_next)
-                    {
-                        if (conn->is_udp && !conn->is_ipv6 && conn->orig_dest_ip == src_ip && conn->orig_dest_port == src_port)
-                        {
-                            if (!found || conn->last_activity > best_activity)
-                            {
-                                target_ip    = conn->src_ip;
-                                target_port  = conn->src_port;
-                                best_activity = conn->last_activity;
-                                found        = TRUE;
-                                winner_conn  = conn;
-                                // Do NOT update last_activity here; doing so mid-loop corrupts
-                                // best_activity comparisons for later entries. Update after.
-                            }
-                        }
-                    }
-                    // Keep winner's session alive (update outside loop so comparisons above
-                    // use the original, unmodified timestamps for all candidates).
-                    if (winner_conn != NULL)
-                        InterlockedExchange64((LONGLONG volatile*)&winner_conn->last_activity, (LONGLONG)GetTickCount64());
-                    ReleaseSRWLockShared(&lock);
-
-                    if (found)
+                    if (find_udp_sender(src_ip, src_port, RULE_ACTION_PROXY,
+                                        &target_ip, &target_port))
                     {
                         struct sockaddr_in target_addr;
                         memset(&target_addr, 0, sizeof(target_addr));
@@ -360,7 +381,9 @@ DWORD WINAPI udp_relay_server(LPVOID arg)
 
                     UINT8 target_ip6[16];
                     UINT16 target_port = 0;
-                    if (find_v6_udp_sender(src_ip6, src_port, target_ip6, &target_port) && udp_relay_socket6 != INVALID_SOCKET)
+                    if (udp_relay_socket6 != INVALID_SOCKET &&
+                        find_v6_udp_sender(src_ip6, src_port, RULE_ACTION_PROXY,
+                                           target_ip6, &target_port))
                     {
                         struct sockaddr_in6 t6;
                         memset(&t6, 0, sizeof(t6));
@@ -374,7 +397,7 @@ DWORD WINAPI udp_relay_server(LPVOID arg)
             }
         }
 
-        // IPv6 UDP packets from application
+        // IPv6 UDP packets from an application or a DIRECT destination
         if (udp_relay_socket6 != INVALID_SOCKET && FD_ISSET(udp_relay_socket6, &read_fds))
         {
             struct sockaddr_in6 from_addr6 = {0};
@@ -387,8 +410,84 @@ DWORD WINAPI udp_relay_server(LPVOID arg)
                 UINT8  dest_ip6[16];
                 UINT16 dest_port = 0;
                 UINT32 proxy_config_id = 0;
+                RuleAction action = RULE_ACTION_PROXY;
+                BOOL have_udp = FALSE;
 
-                if (get_connection_full_v6(from_port, TRUE, dest_ip6, &dest_port, &proxy_config_id))
+                if (g_use_wfp_driver)
+                {
+                    DWORD pid = 0;
+                    have_udp = pb_driver_udp_orig6((const UINT8 *)&from_addr6.sin6_addr, from_port,
+                                                    dest_ip6, &dest_port, &pid);
+                    if (have_udp)
+                    {
+                        char pname[MAX_PROCESS_NAME];
+                        if (get_process_name_from_pid(pid, pname, sizeof(pname))) {
+                            action = match_rule_v6(pname, dest_ip6, dest_port, TRUE,
+                                                   &proxy_config_id);
+                        }
+                        pb_report_connection(pid, NULL, TRUE, 0, dest_ip6, dest_port,
+                                             action, proxy_config_id, TRUE);
+                        if (action == RULE_ACTION_BLOCK)
+                        {
+                            remove_connection(from_port, TRUE, TRUE);
+                            have_udp = FALSE;
+                        }
+                        else
+                        {
+                            add_connection_v6(from_port, TRUE, (const UINT8 *)&from_addr6.sin6_addr,
+                                              dest_ip6, dest_port, proxy_config_id, action);
+                        }
+                    }
+                    else
+                    {
+                        UINT8 target_ip6[16];
+                        UINT16 target_port = 0;
+                        if (find_v6_udp_sender((const UINT8 *)&from_addr6.sin6_addr, from_port,
+                                               RULE_ACTION_DIRECT, target_ip6, &target_port))
+                        {
+                            if (from_port == 53) {
+                                snoop_dns_response(recv_buf, recv_len);
+                            }
+                            struct sockaddr_in6 target_addr6;
+                            memset(&target_addr6, 0, sizeof(target_addr6));
+                            target_addr6.sin6_family = AF_INET6;
+                            memcpy(&target_addr6.sin6_addr, target_ip6, 16);
+                            target_addr6.sin6_port = htons(target_port);
+                            if (sendto(udp_relay_socket6, (char*)recv_buf, recv_len, 0,
+                                       (struct sockaddr *)&target_addr6,
+                                       sizeof(target_addr6)) == SOCKET_ERROR)
+                            {
+                                log_message("[UDP RELAY] Direct IPv6 response to client port "
+                                            "%d failed: %d",
+                                            target_port, WSAGetLastError());
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    have_udp = get_connection_full_v6(from_port, TRUE, dest_ip6, &dest_port,
+                                                       &proxy_config_id, &action);
+                }
+
+                if (have_udp && action == RULE_ACTION_DIRECT)
+                {
+                    struct sockaddr_in6 direct_addr6;
+                    memset(&direct_addr6, 0, sizeof(direct_addr6));
+                    direct_addr6.sin6_family = AF_INET6;
+                    memcpy(&direct_addr6.sin6_addr, dest_ip6, 16);
+                    direct_addr6.sin6_port = htons(dest_port);
+                    if (sendto(udp_relay_socket6, (char*)recv_buf, recv_len, 0,
+                               (struct sockaddr *)&direct_addr6,
+                               sizeof(direct_addr6)) == SOCKET_ERROR)
+                    {
+                        log_message("[UDP RELAY] Direct IPv6 send to port %d failed: %d",
+                                    dest_port, WSAGetLastError());
+                    }
+                    have_udp = FALSE;
+                }
+
+                if (have_udp)
                 {
                     PROXY_CONFIG *cfg = find_proxy_config(proxy_config_id);
                     if (cfg != NULL && cfg->type == PROXY_TYPE_SOCKS5)


### PR DESCRIPTION
Fixes #229.

## Summary

- carry the relay-side `RuleAction` explicitly instead of overloading proxy config id `0`
- connect redirected TCP `DIRECT` flows to their original IPv4/IPv6 destination and reuse the existing bidirectional transfer path
- forward redirected UDP `DIRECT` payloads through the relay listener and route replies with action-aware reverse lookups
- add the missing user-mode IPv6 UDP driver query and IPv6 connection-table insertion without changing the driver IOCTL ABI
- keep `PROXY` reply routing isolated from `DIRECT`, and evict stale UDP sessions when a reused source port resolves to `BLOCK`

## Why

The kernel watchlist redirects every process that has an enabled `PROXY` or `BLOCK` rule, but destination-specific evaluation in the relay can still return `DIRECT`. TCP previously treated config id `0` as the first proxy; UDP dropped every non-`PROXY` result.

Independent runtime evidence for the original failures is recorded in the ProxyBridge TestLab commit linked from #229. The implementation and local checks in this PR are separate from those published runtime results.

## Validation

- `Windows\compile.ps1 -Compiler msvc -NoSign`
  - `ProxyBridgeCore.dll`: passed (`/W4`)
  - native GUI: passed (`/W4`)
  - CLI: passed (`/W4`)
- disposable `/W4 /WX` connection-tracking harness: passed
  - IPv4/IPv6 action isolation
  - source-port reuse re-keying
  - IPv6 destination/config/action round trip
- disposable `/W4 /WX` TCP relay harness: passed
  - IPv4 direct `ping`/`pong`
  - IPv6 direct `ping`/`pong`
- MSVC `/analyze:only` on the four affected implementation files; no diagnostic pointed to a newly added path
- `git diff --check`: passed

## Limits

The driver project currently pins Windows SDK `10.0.28000.0`, which is unavailable on the test host (installed SDK: `10.0.26100.0`). Consequently, this PR does not claim a fresh `.sys` build, signed-driver test, or end-to-end WFP runtime test.

UDP source transparency is unchanged: direct replies use the existing relay listener, so any separate case where an application observes the relay endpoint instead of the original peer remains outside this fix.
